### PR TITLE
Release v2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ Setting changes in `drop_that.cg`:
 - Removed `ApplyConditionsOnDeath`. Conditions are being applied when it makes the most sense, instead of arbitrarily picking which one behaves according to this setting and which doesn't.
 
 # Changelog
+- v2.1.2:
+	- Fixed CharacterDrop named lists not applying modifiers correctly for ragdolled creatures. Eg., EpicLoot settings skipped.
+	- Fixed rarity rolling for EpicLoot not skipping rarities with weight 0.
+- v2.1.1:
+	- Fixed CharacterDrop configuration "ClearAllExistingWhenModified=true" not properly clearing modified tables.
 - v2.1.0:
 	- Added cllc conditions ConditionWorldLevelMin/Max.
 	- Fixed DropTable SetAmountMin/Max not being used for some entities.

--- a/Valheim.DropThat/Configuration/ConfigTypes/CharacterDropConfiguration.cs
+++ b/Valheim.DropThat/Configuration/ConfigTypes/CharacterDropConfiguration.cs
@@ -96,6 +96,8 @@ namespace Valheim.DropThat.Configuration.ConfigTypes
 
         #endregion
 
+        public bool IsFromNamedList { get; set; }
+
         // Inefficient, but will do for now.
         public int Index
         {

--- a/Valheim.DropThat/Configuration/ConfigTypes/CharacterDropListConfigurationFile.cs
+++ b/Valheim.DropThat/Configuration/ConfigTypes/CharacterDropListConfigurationFile.cs
@@ -17,7 +17,10 @@ namespace Valheim.DropThat.Configuration.ConfigTypes
     {
         protected override CharacterDropItemConfiguration InstantiateSubsection(string subsectionName)
         {
-            return new CharacterDropItemConfiguration();
+            return new CharacterDropItemConfiguration()
+            {
+                IsFromNamedList = true,
+            };
         }
     }
 }

--- a/Valheim.DropThat/Drop/CharacterDropSystem/Patches/Patch_Ragdoll_TransferConfigs.cs
+++ b/Valheim.DropThat/Drop/CharacterDropSystem/Patches/Patch_Ragdoll_TransferConfigs.cs
@@ -85,7 +85,8 @@ namespace Valheim.DropThat.Drop.CharacterDropSystem.Patches
                         new DropConfig
                         {
                             Index = x.Key,
-                            ConfigKey = x.Value.Config.SectionKey
+                            ConfigKey = x.Value.Config.SectionKey,
+                            IsList = x.Value.Config.IsFromNamedList,
                         })
                     .ToList();
 
@@ -157,7 +158,20 @@ namespace Valheim.DropThat.Drop.CharacterDropSystem.Patches
                                 return;
                             }
 
-                            if (ConfigurationManager.CharacterDropConfigs.TryGet(configSections[0], out CharacterDropMobConfiguration mobConfig))
+                            if (entry.IsList)
+                            {
+                                if (ConfigurationManager.CharacterDropLists.TryGet(configSections[0], out CharacterDropListConfiguration listConfig))
+                                {
+                                    if (listConfig.TryGet(configSections[1], out CharacterDropItemConfiguration itemConfig))
+                                    {
+                                        TempDropListCache.SetDrop(dropList, entry.Index, new DropExtended
+                                        {
+                                            Config = itemConfig,
+                                        });
+                                    }
+                                }
+                            }
+                            else if (ConfigurationManager.CharacterDropConfigs.TryGet(configSections[0], out CharacterDropMobConfiguration mobConfig))
                             {
                                 if (mobConfig.TryGet(configSections[1], out CharacterDropItemConfiguration itemConfig))
                                 {
@@ -182,6 +196,7 @@ namespace Valheim.DropThat.Drop.CharacterDropSystem.Patches
         {
             public int Index;
             public string ConfigKey;
+            public bool IsList;
         }
     }
 }

--- a/Valheim.DropThat/DropThatPlugin.cs
+++ b/Valheim.DropThat/DropThatPlugin.cs
@@ -8,7 +8,7 @@ namespace Valheim.DropThat
     [BepInDependency("asharppen.valheim.spawn_that", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("randyknapp.mods.epicloot", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("org.bepinex.plugins.creaturelevelcontrol", BepInDependency.DependencyFlags.SoftDependency)]
-    [BepInPlugin("asharppen.valheim.drop_that", "Drop That!", "2.1.1")]
+    [BepInPlugin("asharppen.valheim.drop_that", "Drop That!", "2.1.2")]
     public class DropThatPlugin : BaseUnityPlugin
     {
         // Awake is called once when both the game and the plug-in are loaded

--- a/Valheim.DropThat/Integrations/EpicLootIntegration/ItemService.cs
+++ b/Valheim.DropThat/Integrations/EpicLootIntegration/ItemService.cs
@@ -147,23 +147,23 @@ namespace Valheim.DropThat.Integrations.EpicLootIntegration
             float ongoingSum = 0;
 
             ongoingSum += config.RarityWeightUnique;
-            if (random <= ongoingSum)
+            if (config.RarityWeightUnique > 0 && random <= ongoingSum)
                 return Rarity.Unique;
 
             ongoingSum += config.RarityWeightLegendary;
-            if (random <= ongoingSum)
+            if (config.RarityWeightLegendary > 0 && random <= ongoingSum)
                 return Rarity.Legendary;
 
             ongoingSum += config.RarityWeightEpic;
-            if (random <= ongoingSum)
+            if (config.RarityWeightEpic > 0 && random <= ongoingSum)
                 return Rarity.Epic;
 
             ongoingSum += config.RarityWeightRare;
-            if (random <= ongoingSum)
+            if (config.RarityWeightRare > 0 && random <= ongoingSum)
                 return Rarity.Rare;
 
             ongoingSum += config.RarityWeightMagic;
-            if (random <= ongoingSum)
+            if (config.RarityWeightMagic > 0 && random <= ongoingSum)
                 return Rarity.Magic;
 
             return Rarity.None;

--- a/Valheim.DropThat/Properties/AssemblyInfo.cs
+++ b/Valheim.DropThat/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.1.0")]
-[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyVersion("2.1.2.0")]
+[assembly: AssemblyFileVersion("2.1.2.0")]

--- a/Valheim.DropThat/ThunderstoreResources/README.md
+++ b/Valheim.DropThat/ThunderstoreResources/README.md
@@ -84,6 +84,9 @@ Setting changes in `drop_that.cg`:
 - Removed `ApplyConditionsOnDeath`. Conditions are being applied when it makes the most sense, instead of arbitrarily picking which one behaves according to this setting and which doesn't.
 
 # Changelog
+- v2.1.2:
+	- Fixed CharacterDrop named lists not applying modifiers correctly for ragdolled creatures. Eg., EpicLoot settings skipped.
+	- Fixed rarity rolling for EpicLoot not skipping rarities with weight 0.
 - v2.1.1:
 	- Fixed CharacterDrop configuration "ClearAllExistingWhenModified=true" not properly clearing modified tables.
 - v2.1.0:

--- a/Valheim.DropThat/ThunderstoreResources/manifest.json
+++ b/Valheim.DropThat/ThunderstoreResources/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Drop_That",
-  "version_number": "2.1.1",
+  "version_number": "2.1.2",
   "website_url": "https://github.com/ASharpPen/Valheim.DropThat",
   "description": "Tool for configuring mob loot tables.",
   "dependencies": [


### PR DESCRIPTION
- Fixed CharacterDrop named lists not applying modifiers correctly for ragdolled creatures. Eg., EpicLoot settings skipped.
- Fixed rarity rolling for EpicLoot not skipping rarities with weight 0.