### PR TITLE
Release v2.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ If you feel like it
 <a href="https://www.buymeacoffee.com/asharppen"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=&slug=asharppen&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
 
 # Changelog
+- v2.3.3:
+	- Fixed DropTable Epic Loot modifier. Items should now properly be able to roll with non-unique rarity.
+	- Fixed detection of Spawn That installation.
+	- Fixed potential transpiler conflict.
 - v2.3.2:
 	- Null checks null checks null checks. 
 	- Fixed issue with debug file creation breaking during startup, due to unexpected empty objects.

--- a/Valheim.DropThat/Drop/CharacterDropSystem/Conditions/ModSpecific/ConditionLoaderSpawnThat.cs
+++ b/Valheim.DropThat/Drop/CharacterDropSystem/Conditions/ModSpecific/ConditionLoaderSpawnThat.cs
@@ -6,7 +6,7 @@ namespace Valheim.DropThat.Drop.CharacterDropSystem.Conditions.ModSpecific
 {
     internal static class ConditionLoaderSpawnThat
     {
-        public static bool InstalledSpawnThat { get; } = Type.GetType("Valheim.SpawnThat.SpawnThatPlugin, Valheim.SpawnThat") is not null;
+        public static bool InstalledSpawnThat { get; } = BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey("asharppen.valheim.spawn_that");
 
         public static ConditionTemplateId ConditionTemplateId
         {

--- a/Valheim.DropThat/Drop/DropTableSystem/Managers/DropConfigManager.cs
+++ b/Valheim.DropThat/Drop/DropTableSystem/Managers/DropConfigManager.cs
@@ -99,12 +99,6 @@ namespace Valheim.DropThat.Drop.DropTableSystem.Managers
                 InsertDrop(drops, config, context.EntityConfig);
             }
 
-            // Go through all the config entries
-            foreach (var dropEntry in context.EntityConfig.Subsections.OrderBy(x => x.Value.Index))
-            {
-                InsertDrop(drops, dropEntry.Value, context.EntityConfig);
-            }
-
             return drops;
         }
 

--- a/Valheim.DropThat/Drop/DropTableSystem/Managers/DropTableManager.cs
+++ b/Valheim.DropThat/Drop/DropTableSystem/Managers/DropTableManager.cs
@@ -19,7 +19,7 @@ namespace Valheim.DropThat.Drop.DropTableSystem
             Log.LogDebug($"Dropping {drops.Count} items:");
             foreach(var drop in drops)
             {
-                Log.LogDebug($"\t{drop}");
+                Log.LogDebug($"\t{drop.m_shared.m_name}");
             }
 #endif
 

--- a/Valheim.DropThat/Drop/DropTableSystem/Modifiers/ModSpecific/ModEpicLoot/ModifierMagicItem.cs
+++ b/Valheim.DropThat/Drop/DropTableSystem/Modifiers/ModSpecific/ModEpicLoot/ModifierMagicItem.cs
@@ -18,6 +18,9 @@ namespace Valheim.DropThat.Drop.DropTableSystem.Modifiers.ModSpecific.ModEpicLoo
 
             if (config is null)
             {
+#if DEBUG
+                Log.LogDebug("Found no config for drop template.");
+#endif
                 return;
             }
 
@@ -49,6 +52,10 @@ namespace Valheim.DropThat.Drop.DropTableSystem.Modifiers.ModSpecific.ModEpicLoo
 
             if (config is null)
             {
+#if DEBUG
+                Log.LogDebug("Found no config for drop template.");
+#endif
+
                 return;
             }
 
@@ -68,6 +75,9 @@ namespace Valheim.DropThat.Drop.DropTableSystem.Modifiers.ModSpecific.ModEpicLoo
 
             if (magicItemData is not null)
             {
+#if DEBUG
+                Log.LogTrace($"Assigning magickified drop '{drop.m_shared.m_name}'.");
+#endif
                 drop = magicItemData;
             }
         }

--- a/Valheim.DropThat/Drop/DropTableSystem/Patches/Patch_DropTable_GetDrops_Overhaul.cs
+++ b/Valheim.DropThat/Drop/DropTableSystem/Patches/Patch_DropTable_GetDrops_Overhaul.cs
@@ -48,16 +48,16 @@ namespace Valheim.DropThat.Drop.DropTableSystem.Patches
     {
         [HarmonyPatch(nameof(DropTable.GetDropListItems))]
         [HarmonyTranspiler]
-        private static IEnumerable<CodeInstruction> DropListItemsOverhaul(IEnumerable<CodeInstruction> instructions)
+        private static IEnumerable<CodeInstruction> DropListItemsOverhaul(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
-            return new CodeMatcher(instructions)
+            return new CodeMatcher(instructions, generator)
                 // Move to start, and insert overhaul
                 .Start()
                 .InsertAndAdvance(new CodeInstruction(OpCodes.Ldarg_0))
                 .InsertAndAdvance(new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Patch_DropTable_GetDrops_Overhaul), nameof(GetDropListItems))))
                 .InsertAndAdvance(new CodeInstruction(OpCodes.Ret))
                 // Set label for where the original code would have started to run.
-                .AddLabel(out Label originalStart)
+                .CreateLabel(out Label originalStart)
                 // Move back again to start, and insert check and skip of overhaul.
                 .Start()
                 .InsertAndAdvance(new CodeInstruction(OpCodes.Ldarg_0))
@@ -68,9 +68,9 @@ namespace Valheim.DropThat.Drop.DropTableSystem.Patches
 
         [HarmonyPatch("GetDropList", new[] {typeof(int)})]
         [HarmonyTranspiler]
-        private static IEnumerable<CodeInstruction> DropListOverhaul(IEnumerable<CodeInstruction> instructions)
+        private static IEnumerable<CodeInstruction> DropListOverhaul(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
-            return new CodeMatcher(instructions)
+            return new CodeMatcher(instructions, generator)
                 // Move to start, and insert overhaul
                 .Start()
                 .InsertAndAdvance(new CodeInstruction(OpCodes.Ldarg_0))
@@ -78,7 +78,7 @@ namespace Valheim.DropThat.Drop.DropTableSystem.Patches
                 .InsertAndAdvance(new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Patch_DropTable_GetDrops_Overhaul), nameof(GetDropList))))
                 .InsertAndAdvance(new CodeInstruction(OpCodes.Ret))
                 // Set label for where the original code would have started to run.
-                .AddLabel(out Label originalStart) 
+                .CreateLabel(out Label originalStart) 
                 // Move back again to start, and insert check and skip of overhaul.
                 .Start()
                 .InsertAndAdvance(new CodeInstruction(OpCodes.Ldarg_0))

--- a/Valheim.DropThat/Drop/DropTableSystem/Patches/Patch_OnDrop.cs
+++ b/Valheim.DropThat/Drop/DropTableSystem/Patches/Patch_OnDrop.cs
@@ -178,6 +178,10 @@ namespace Valheim.DropThat.Drop.DropTableSystem.Patches
                 {
                     try
                     {
+#if DEBUG
+                        Log.LogTrace($"Applying modifier '{modifier.GetType().Name}'");
+#endif
+
                         modifier.Modify(ref item, template, container.transform.position);
                     }
                     catch (Exception e)

--- a/Valheim.DropThat/DropThatPlugin.cs
+++ b/Valheim.DropThat/DropThatPlugin.cs
@@ -8,7 +8,7 @@ namespace Valheim.DropThat
     [BepInDependency("asharppen.valheim.spawn_that", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("randyknapp.mods.epicloot", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("org.bepinex.plugins.creaturelevelcontrol", BepInDependency.DependencyFlags.SoftDependency)]
-    [BepInPlugin("asharppen.valheim.drop_that", "Drop That!", "2.3.2")]
+    [BepInPlugin("asharppen.valheim.drop_that", "Drop That!", "2.3.3")]
     public class DropThatPlugin : BaseUnityPlugin
     {
         // Awake is called once when both the game and the plug-in are loaded

--- a/Valheim.DropThat/Integrations/EpicLootIntegration/ItemRoller.cs
+++ b/Valheim.DropThat/Integrations/EpicLootIntegration/ItemRoller.cs
@@ -1,6 +1,7 @@
 ﻿using ExtendedItemDataFramework;
 using Valheim.DropThat.Configuration.ConfigTypes;
 using UnityEngine;
+using Valheim.DropThat.Core;
 
 namespace Valheim.DropThat.Integrations.EpicLootIntegration
 {
@@ -10,12 +11,19 @@ namespace Valheim.DropThat.Integrations.EpicLootIntegration
         {
             if (!EpicLoot.EpicLoot.CanBeMagicItem(itemData))
             {
+#if DEBUG
+                Log.LogTrace($"Item '{itemData.m_shared.m_name}' can't be made magic.");
+#endif
                 return null;
             }
 
             var extendedItemData = new ExtendedItemData(itemData);
 
             var rarity = ItemService.RollRarity(config);
+
+#if DEBUG
+            Log.LogTrace($"Item '{itemData.m_shared.m_name}' rolled rarity '{rarity}'.");
+#endif
 
             if (rarity is Rarity.None)
             {

--- a/Valheim.DropThat/Integrations/EpicLootIntegration/ItemService.cs
+++ b/Valheim.DropThat/Integrations/EpicLootIntegration/ItemService.cs
@@ -106,7 +106,7 @@ namespace Valheim.DropThat.Integrations.EpicLootIntegration
             magicComponent.SetMagicItem(magicItem);
             InitializeMagicItem.Invoke(null, new[] { itemData });
 
-            return itemDrop;
+            return itemData;
         }
 
         private static MagicItemEffectDefinition RollWeightedEffect(List<MagicItemEffectDefinition> magicEffects, bool removeSelected)

--- a/Valheim.DropThat/Integrations/EpicLootIntegration/ItemService.cs
+++ b/Valheim.DropThat/Integrations/EpicLootIntegration/ItemService.cs
@@ -97,7 +97,11 @@ namespace Valheim.DropThat.Integrations.EpicLootIntegration
             MagicItemComponent magicComponent = itemData.AddComponent<MagicItemComponent>();
 
             var luck = LootRoller.GetLuckFactor(position);
-            MagicItem magicItem = magicItem = LootRoller.RollMagicItem(rarity, itemData, luck);
+            MagicItem magicItem = LootRoller.RollMagicItem(rarity, itemData, luck);
+
+#if DEBUG
+            Log.LogTrace("\t" + magicItem.Effects.Join(x => x.EffectType));
+#endif
 
             magicComponent.SetMagicItem(magicItem);
             InitializeMagicItem.Invoke(null, new[] { itemData });

--- a/Valheim.DropThat/Properties/AssemblyInfo.cs
+++ b/Valheim.DropThat/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.2.0")]
-[assembly: AssemblyFileVersion("2.3.2.0")]
+[assembly: AssemblyVersion("2.3.3.0")]
+[assembly: AssemblyFileVersion("2.3.3.0")]

--- a/Valheim.DropThat/ThunderstoreResources/manifest.json
+++ b/Valheim.DropThat/ThunderstoreResources/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Drop_That",
-  "version_number": "2.3.2",
+  "version_number": "2.3.3",
   "website_url": "https://github.com/ASharpPen/Valheim.DropThat",
   "description": "Tool for configuring loot tables.",
   "dependencies": [

--- a/Valheim.DropThat/Utilities/CodeMatcherExtensions.cs
+++ b/Valheim.DropThat/Utilities/CodeMatcherExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using HarmonyLib;
 using System;
-using System.Reflection.Emit;
 using Valheim.DropThat.Core;
 
 namespace Valheim.DropThat.Utilities
@@ -10,13 +9,6 @@ namespace Valheim.DropThat.Utilities
         public static CodeMatcher GetPosition(this CodeMatcher codeMatcher, out int position)
         {
             position = codeMatcher.Pos;
-            return codeMatcher;
-        }
-
-        public static CodeMatcher AddLabel(this CodeMatcher codeMatcher, out Label label)
-        {
-            label = new Label();
-            codeMatcher.AddLabels(new[] { label });
             return codeMatcher;
         }
 


### PR DESCRIPTION
- Fixed DropTable Epic Loot modifier. Items should now properly be able to roll with non-unique rarity. Closes #135 
- Fixed detection of Spawn That installation.
- Fixed potential transpiler conflict.